### PR TITLE
Add responsive mobile sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -208,3 +208,42 @@ html, body, #mapid {
     transform: rotate(180deg);
 
 }
+
+@media (max-width: 600px) {
+    #side-bar {
+        width: 100%;
+        height: 60%;
+        left: 0;
+        top: auto;
+        bottom: 0;
+        transform: translateY(100%);
+    }
+
+    #side-bar.active {
+        transform: translateY(0);
+    }
+
+    .toggle-button {
+        position: fixed;
+        left: 50%;
+        bottom: 0;
+        top: auto;
+        width: 60px;
+        height: 20px;
+        border-radius: 4px 4px 0 0;
+        transform: translateX(-50%);
+    }
+
+    #side-bar.active .toggle-button {
+        bottom: 60%;
+    }
+
+    #toggle-button-image {
+        top: 0;
+        transform: rotate(-90deg);
+    }
+
+    #side-bar.active #toggle-button-image {
+        transform: rotate(90deg);
+    }
+}


### PR DESCRIPTION
## Summary
- add responsive rules so the sidebar can slide up from bottom on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840050162488323acfb10aaf7225751